### PR TITLE
Fix typo in conversion example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -563,7 +563,7 @@ FROM (
         ON ( 
             y.customer = e.customer  AND
             y.ts > e.ts  AND
-            y.ts <= NVL(c.activity_repeated_at, CAST('2100-01-01' AS TIMESTAMP)) 
+            y.ts <= NVL(e.activity_repeated_at, CAST('2100-01-01' AS TIMESTAMP)) 
         )
     WHERE (
         e.activity = 'opened_email' AND


### PR DESCRIPTION
Change from "c" to "e" in the conversion example. This seems to be a typo, as c is not defined in the example.